### PR TITLE
feat - explore page

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -1,5 +1,12 @@
 import { Route, Routes } from "react-router-dom";
-import { Feed, SignUp, SignIn, LandingPage, Profile } from "./pages/index";
+import {
+  Feed,
+  SignUp,
+  SignIn,
+  LandingPage,
+  Profile,
+  Explore,
+} from "./pages/index";
 import { RequireAuth } from "./components/index";
 
 export function Router() {
@@ -7,6 +14,7 @@ export function Router() {
     <Routes>
       <Route path="" element={<LandingPage />}></Route>
       <Route path="/signIn" element={<SignIn />}></Route>
+      <Route path="/explore" element={<Explore />}></Route>
       <Route
         path="/feed"
         element={

--- a/src/components/AddComment.tsx
+++ b/src/components/AddComment.tsx
@@ -1,0 +1,108 @@
+import React from "react";
+import { useAppDispatch, useAppSelector } from "../redux/customHook";
+import { RootState } from "../redux/store";
+import { FULFILLED, LOADING } from "../utilities/constants/api-status";
+import {
+  Avatar,
+  ListItem,
+  ListItemAvatar,
+  ListItemText,
+  Typography,
+  TextField,
+  LoadingButton,
+} from "../utilities/material-ui/material-components";
+import { grey } from "../utilities/material-ui/material-colors";
+import { addComment } from "../redux/slices/feedSlice";
+import { v4 as uuid } from "uuid";
+import { useLocation, useNavigate } from "react-router-dom";
+
+export function AddComment({ id }: { id: string }) {
+  const location = useLocation();
+  const { userDetails, authToken } = useAppSelector(
+    (state: RootState) => state.authentication
+  );
+  const [commentError, setCommentError] = React.useState("");
+  const dispatch = useAppDispatch();
+  const navigate = useNavigate();
+  const { addCommentAPIStatus } = useAppSelector(
+    (state: RootState) => state.feed
+  );
+  const [comment, setComment] = React.useState("");
+
+  React.useEffect(() => {
+    if (addCommentAPIStatus === FULFILLED) {
+      setComment("");
+    }
+  }, [addCommentAPIStatus]);
+
+  const addNewComment = () => {
+    if (authToken) {
+      comment
+        ? dispatch(
+            addComment({
+              token: authToken,
+              id,
+              commentData: {
+                _id: uuid(),
+                username: userDetails.username,
+                firstName: userDetails.firstName,
+                lastName: userDetails.lastName,
+                commentText: comment,
+              },
+            })
+          )
+        : setCommentError("Required");
+    } else {
+      navigate("/signin", { state: { from: location } });
+    }
+  };
+
+  return (
+    <ListItem alignItems="flex-start" sx={{ p: { xs: 0.5, md: 1 }, gap: 2 }}>
+      <ListItemAvatar sx={{ minWidth: 0 }}>
+        <Avatar
+          sx={{
+            bgcolor: grey[400],
+            height: "2rem",
+            width: "2rem",
+            fontSize: "1rem",
+          }}
+        >
+          {userDetails.firstName[0]}
+        </Avatar>
+      </ListItemAvatar>
+      <ListItemText
+        primary={`${userDetails.firstName} ${userDetails.lastName}`}
+        secondary={
+          <Typography
+            component="div"
+            sx={{ display: "flex", flexWrap: "wrap" }}
+          >
+            <TextField
+              placeholder="Add a comment..."
+              variant="standard"
+              multiline
+              value={comment}
+              sx={{ flexGrow: 1, fontSize: 14 }}
+              error={commentError !== ""}
+              helperText={commentError}
+              onChange={(e) => {
+                setComment(e.target.value);
+                setCommentError("");
+              }}
+            />
+            <LoadingButton
+              loading={addCommentAPIStatus === LOADING}
+              variant="text"
+              size="small"
+              sx={{ ml: "auto" }}
+              onClick={addNewComment}
+            >
+              POST
+            </LoadingButton>
+          </Typography>
+        }
+      />
+    </ListItem>
+  );
+}

--- a/src/components/AddQuestionModal.tsx
+++ b/src/components/AddQuestionModal.tsx
@@ -14,28 +14,11 @@ import { addQuestion } from "../redux/slices/feedSlice";
 import { RootState } from "../redux/store";
 import { NewQuestion } from "../types/NewQuestion";
 import { FULFILLED, LOADING } from "../utilities/constants/api-status";
-
+import { tags } from "../utilities/data/tags";
 interface AddQuestionProp {
   open: boolean;
   setOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }
-
-const tags = [
-  "Cake",
-  "Baking",
-  "Baking Tools",
-  "Recipes",
-  "Cake Decoration",
-  "Pastry",
-  "Donuts",
-  "Breads",
-  "Wheat Bread",
-  "Cookies",
-  "Business",
-  "Icing",
-  "Experience",
-  "Bakers",
-];
 
 interface AddQuestionErrorsType {
   questionTitleError: string;
@@ -140,7 +123,7 @@ export function AddQuestionModal({ open, setOpen }: AddQuestionProp) {
             updateFormData("questionTitle", event.target.value)
           }
           sx={{ my: 1 }}
-          autoComplete="false"
+          autoComplete="off"
         />
         <TextField
           id="question-text"
@@ -158,12 +141,11 @@ export function AddQuestionModal({ open, setOpen }: AddQuestionProp) {
             updateFormData("questionText", event.target.value)
           }
           fullWidth
-          autoComplete="false"
+          autoComplete="off"
         />
         <Autocomplete
           multiple
           size="small"
-          freeSolo
           sx={{ my: 1 }}
           id="tags-standard"
           value={addQuestionData.tags}

--- a/src/components/CommentSection.tsx
+++ b/src/components/CommentSection.tsx
@@ -1,0 +1,52 @@
+import { useLocation, useNavigate } from "react-router-dom";
+import { useAppSelector } from "../redux/customHook";
+import { RootState } from "../redux/store";
+import { Question } from "../types/Question";
+import { AddComment } from "./AddComment";
+import { Comments } from "./Comments";
+import {
+  Collapse,
+  Divider,
+  List,
+  Typography,
+} from "../utilities/material-ui/material-components";
+export function CommentSection({
+  question,
+  expanded,
+}: {
+  question: Question;
+  expanded: boolean;
+}) {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const { authToken } = useAppSelector(
+    (state: RootState) => state.authentication
+  );
+
+  return (
+    <Collapse in={expanded} timeout="auto" unmountOnExit>
+      <Divider />
+      <List sx={{ width: "100%", bgcolor: "background.paper" }}>
+        {authToken ? (
+          <AddComment id={question._id} />
+        ) : (
+          <Typography
+            variant="body1"
+            p={1.5}
+            color="primary"
+            component="p"
+            sx={{ cursor: "pointer" }}
+            onClick={() => navigate("/signin", { state: { from: location } })}
+            fontWeight={600}
+          >
+            Sign in to comment
+          </Typography>
+        )}
+
+        {question.comments.map((comment) => (
+          <Comments comment={comment} key={comment._id} />
+        ))}
+      </List>
+    </Collapse>
+  );
+}

--- a/src/components/Comments.tsx
+++ b/src/components/Comments.tsx
@@ -1,0 +1,31 @@
+import { Comment } from "../types/Comment";
+import {
+  Avatar,
+  ListItem,
+  ListItemAvatar,
+  ListItemText,
+} from "../utilities/material-ui/material-components";
+import { grey } from "../utilities/material-ui/material-colors";
+
+export function Comments({ comment }: { comment: Comment }) {
+  return (
+    <ListItem alignItems="flex-start" sx={{ p: { xs: 0.5, md: 1 }, gap: 2 }}>
+      <ListItemAvatar sx={{ minWidth: 0 }}>
+        <Avatar
+          sx={{
+            bgcolor: grey[400],
+            height: "2rem",
+            width: "2rem",
+            fontSize: "1rem",
+          }}
+        >
+          {comment.firstName[0]}
+        </Avatar>
+      </ListItemAvatar>
+      <ListItemText
+        primary={`${comment.firstName} ${comment.lastName}`}
+        secondary={comment.commentText}
+      />
+    </ListItem>
+  );
+}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -63,12 +63,12 @@ export function Navbar() {
       sx={{ zIndex: (theme) => theme.zIndex.drawer + 1 }}
     >
       <Toolbar disableGutters variant="dense" sx={{ px: 2 }}>
-        <Link to="/">
+        <Link to="/explore">
           <Box sx={{ display: { xs: "none", md: "flex" }, height: "2rem" }}>
             <img src="assets/logo.png" alt="Bakers' Forum" />
           </Box>
         </Link>
-        <Link to="/">
+        <Link to="/explore">
           <Box
             sx={{
               flexGrow: 1,

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -10,7 +10,7 @@ import {
   Tooltip,
   Typography,
 } from "../utilities/material-ui/material-components";
-import { LogoutIcon } from "../utilities/material-ui/material-icons";
+import { LogoutIcon, LoginIcon } from "../utilities/material-ui/material-icons";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import { useAppDispatch, useAppSelector } from "../redux/customHook";
 import { logout } from "../redux/slices/authenticationSlice";
@@ -80,13 +80,11 @@ export function Navbar() {
           </Box>
         </Link>
 
-        {(location.pathname === "/feed" ||
-          location.pathname === "/profile") && (
+        {authToken ? (
           <Box
             sx={{
               flexGrow: 0,
               ml: "auto",
-              pr: 1.5,
               display: { xs: "none", md: "flex" },
             }}
           >
@@ -96,6 +94,21 @@ export function Navbar() {
               </IconButton>
             </Tooltip>
           </Box>
+        ) : (
+          !location.pathname.includes("sign") && (
+            <Box
+              sx={{
+                flexGrow: 0,
+                ml: "auto",
+              }}
+            >
+              <Tooltip title="Log in">
+                <IconButton onClick={() => navigate("/signin")}>
+                  <LoginIcon sx={{ color: "white" }} />
+                </IconButton>
+              </Tooltip>
+            </Box>
+          )
         )}
         {authToken && (
           <Box
@@ -151,7 +164,7 @@ export function Navbar() {
                   dispatch(logout());
                   handleCloseUserMenu();
                 }}
-                sx={{ pr: 3 }}
+                sx={{ pr: 3, width: "100%" }}
               >
                 <Typography textAlign="center">Logout</Typography>
               </MenuItem>

--- a/src/components/QuestionCard.tsx
+++ b/src/components/QuestionCard.tsx
@@ -15,25 +15,17 @@ import {
   CardContent,
   CardHeader,
   Chip,
-  Collapse,
   Divider,
   IconButton,
-  List,
   ListItem,
   ListItemAvatar,
   ListItemText,
   Typography,
-  TextField,
-  LoadingButton,
 } from "../utilities/material-ui/material-components";
-import { useAppDispatch, useAppSelector } from "../redux/customHook";
-import { RootState } from "../redux/store";
 import { Question } from "../types/Question";
 import { VoteSection } from "./VoteSection";
-import { addComment } from "../redux/slices/feedSlice";
-import { v4 as uuid } from "uuid";
-import { LOADING, FULFILLED } from "../utilities/constants/api-status";
-interface ExpandMoreProps extends IconButtonProps {
+import { CommentSection } from "./CommentSection";
+interface ExpandCommentsProps extends IconButtonProps {
   expand: boolean;
 }
 
@@ -41,7 +33,7 @@ interface QuestionCardProp {
   question: Question;
 }
 
-const ExpandMore = styled((props: ExpandMoreProps) => {
+const ExpandComments = styled((props: ExpandCommentsProps) => {
   const { expand, ...other } = props;
   return <IconButton {...other} />;
 })(({ theme }) => ({
@@ -53,25 +45,11 @@ const ExpandMore = styled((props: ExpandMoreProps) => {
 
 export function QuestionCard({ question }: QuestionCardProp) {
   const [expanded, setExpanded] = React.useState(false);
-  const [comment, setComment] = React.useState("");
-  const [commentError, setCommentError] = React.useState("");
-  const dispatch = useAppDispatch();
-  const { userDetails, authToken } = useAppSelector(
-    (state: RootState) => state.authentication
-  );
-  const { addCommentAPIStatus } = useAppSelector(
-    (state: RootState) => state.feed
-  );
 
   const handleExpandClick = () => {
     setExpanded(!expanded);
   };
 
-  React.useEffect(() => {
-    if (addCommentAPIStatus === FULFILLED) {
-      setComment("");
-    }
-  }, [addCommentAPIStatus]);
   return (
     <Card sx={{ display: "flex" }}>
       <VoteSection question={question} />
@@ -125,7 +103,7 @@ export function QuestionCard({ question }: QuestionCardProp) {
             px: { xs: 0.5 },
           }}
         >
-          <ExpandMore
+          <ExpandComments
             sx={{ m: 0 }}
             expand={expanded}
             onClick={handleExpandClick}
@@ -133,7 +111,7 @@ export function QuestionCard({ question }: QuestionCardProp) {
             aria-label="show more"
           >
             <CommentOutlinedIcon />
-          </ExpandMore>
+          </ExpandComments>
           <IconButton aria-label="share">
             <ShareOutlinedIcon />
           </IconButton>
@@ -141,100 +119,7 @@ export function QuestionCard({ question }: QuestionCardProp) {
             <BookmarkBorderOutlinedIcon />
           </IconButton>
         </CardActions>
-        <Collapse in={expanded} timeout="auto" unmountOnExit>
-          <Divider />
-          <List sx={{ width: "100%", bgcolor: "background.paper" }}>
-            <ListItem
-              alignItems="flex-start"
-              sx={{ p: { xs: 0.5, md: 1 }, gap: 2 }}
-            >
-              <ListItemAvatar sx={{ minWidth: 0 }}>
-                <Avatar
-                  sx={{
-                    bgcolor: grey[400],
-                    height: "2rem",
-                    width: "2rem",
-                    fontSize: "1rem",
-                  }}
-                >
-                  {userDetails.firstName[0]}
-                </Avatar>
-              </ListItemAvatar>
-              <ListItemText
-                primary={`${userDetails.firstName} ${userDetails.lastName}`}
-                secondary={
-                  <Typography
-                    component="div"
-                    sx={{ display: "flex", flexWrap: "wrap" }}
-                  >
-                    <TextField
-                      placeholder="Add a comment..."
-                      variant="standard"
-                      multiline
-                      value={comment}
-                      sx={{ flexGrow: 1, fontSize: 14 }}
-                      error={commentError !== ""}
-                      helperText={commentError}
-                      onChange={(e) => {
-                        setComment(e.target.value);
-                        setCommentError("");
-                      }}
-                    />
-                    <LoadingButton
-                      loading={addCommentAPIStatus === LOADING}
-                      variant="text"
-                      size="small"
-                      sx={{ ml: "auto" }}
-                      onClick={() => {
-                        comment
-                          ? dispatch(
-                              addComment({
-                                token: authToken,
-                                id: question._id,
-                                commentData: {
-                                  _id: uuid(),
-                                  username: userDetails.username,
-                                  firstName: userDetails.firstName,
-                                  lastName: userDetails.lastName,
-                                  commentText: comment,
-                                },
-                              })
-                            )
-                          : setCommentError("Required");
-                      }}
-                    >
-                      POST
-                    </LoadingButton>
-                  </Typography>
-                }
-              />
-            </ListItem>
-            {question.comments.map((comment) => (
-              <ListItem
-                alignItems="flex-start"
-                sx={{ p: { xs: 0.5, md: 1 }, gap: 2 }}
-                key={comment._id}
-              >
-                <ListItemAvatar sx={{ minWidth: 0 }}>
-                  <Avatar
-                    sx={{
-                      bgcolor: grey[400],
-                      height: "2rem",
-                      width: "2rem",
-                      fontSize: "1rem",
-                    }}
-                  >
-                    {comment.firstName[0]}
-                  </Avatar>
-                </ListItemAvatar>
-                <ListItemText
-                  primary={`${comment.firstName} ${comment.lastName}`}
-                  secondary={comment.commentText}
-                />
-              </ListItem>
-            ))}
-          </List>
-        </Collapse>
+        <CommentSection question={question} expanded={expanded} />
       </Box>
     </Card>
   );

--- a/src/components/QuestionCardsSection.tsx
+++ b/src/components/QuestionCardsSection.tsx
@@ -3,6 +3,7 @@ import {
   IconButton,
   Tooltip,
   Typography,
+  ToggleButton,
 } from "../utilities/material-ui/material-components";
 import { QuestionCard } from "./QuestionCard";
 import { FilterListIcon } from "../utilities/material-ui/material-icons";
@@ -16,6 +17,7 @@ import { DataLoader } from "./DataLoader";
 import { NoPostsMessage } from "./NoPostsMessage";
 import { grey } from "../utilities/material-ui/material-colors";
 import { useLocation } from "react-router-dom";
+import { tags } from "../utilities/data/tags";
 
 export function QuestionCardsSection({
   title,
@@ -29,7 +31,6 @@ export function QuestionCardsSection({
   const [anchorEl, setAnchorEl] = React.useState<HTMLButtonElement | null>(
     null
   );
-
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     setAnchorEl(event.currentTarget);
   };
@@ -74,6 +75,26 @@ export function QuestionCardsSection({
           </React.Fragment>
         )}
       </Box>
+      {/* for now this is static */}
+      {location.pathname === "/explore" && (
+        <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap" }}>
+          {tags.map((tag, index) => (
+            <ToggleButton
+              key={index}
+              value="check"
+              sx={{ py: 0.5 }}
+              size="small"
+              color="primary"
+              selected={index % 4 === 0}
+              // onChange={() => {
+              //   setSelected(!selected);
+              // }}
+            >
+              {tag}
+            </ToggleButton>
+          ))}
+        </Box>
+      )}
       {questions &&
         questions?.length > 0 &&
         questions?.map((question) => (

--- a/src/components/Sidenav.tsx
+++ b/src/components/Sidenav.tsx
@@ -8,7 +8,9 @@ import {
 } from "../utilities/material-ui/material-components";
 import React from "react";
 import { AddQuestionModal } from "./AddQuestionModal";
-import { Link, useLocation } from "react-router-dom";
+import { Link, useLocation, useNavigate } from "react-router-dom";
+import { useAppSelector } from "../redux/customHook";
+import { RootState } from "../redux/store";
 
 const sidenavItem = [
   {
@@ -48,6 +50,16 @@ export function Sidenav({
   setOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }) {
   const location = useLocation();
+  const navigate = useNavigate();
+  const { authToken } = useAppSelector(
+    (state: RootState) => state.authentication
+  );
+
+  const createNewPost = () => {
+    authToken
+      ? handleOpen()
+      : navigate("/signin", { state: { from: location } });
+  };
   return (
     <Box sx={{ flexShrink: 0, display: { xs: "none", md: "block" } }}>
       <Box sx={{ overflow: "auto" }}>
@@ -70,7 +82,7 @@ export function Sidenav({
             </Link>
           ))}
         </List>
-        <Button sx={{ m: 2 }} variant="contained" onClick={handleOpen}>
+        <Button sx={{ m: 2 }} variant="contained" onClick={createNewPost}>
           Create New Post
         </Button>
 

--- a/src/components/VoteSection.tsx
+++ b/src/components/VoteSection.tsx
@@ -10,18 +10,27 @@ import { useAppDispatch, useAppSelector } from "../redux/customHook";
 import { addVote } from "../redux/slices/feedSlice";
 import { RootState } from "../redux/store";
 import { Question } from "../types/Question";
+import { useLocation, useNavigate } from "react-router-dom";
 
 export function VoteSection({ question }: { question: Question }) {
   const dispatch = useAppDispatch();
+  const location = useLocation();
+  const navigate = useNavigate();
   const { authToken, userDetails } = useAppSelector(
     (state: RootState) => state.authentication
   );
   const updateVote = (type: string, key: string) => {
-    // if question is already upvoted or downvoted
-    if (question.votes[key as keyof Vote].includes(userDetails.username)) {
-      dispatch(addVote({ token: authToken, id: question._id, vote: "unvote" }));
+    if (authToken) {
+      // if question is already upvoted or downvoted
+      if (question.votes[key as keyof Vote].includes(userDetails.username)) {
+        dispatch(
+          addVote({ token: authToken, id: question._id, vote: "unvote" })
+        );
+      } else {
+        dispatch(addVote({ token: authToken, id: question._id, vote: type }));
+      }
     } else {
-      dispatch(addVote({ token: authToken, id: question._id, vote: type }));
+      navigate("/signin", { state: { from: location } });
     }
   };
 
@@ -30,11 +39,11 @@ export function VoteSection({ question }: { question: Question }) {
     // Downvoted/upvoted by: user1, user2, user3
     let finalText =
       length > 0
-        ? `@${question.votes[type as keyof Vote].slice(0, 3).join(", @")}`
+        ? `@${question.votes[type as keyof Vote].slice(0, 1).join(", @")}`
         : `None`;
-    // if number of votes more than 3 -> add  `+ "remaining users" more`
-    if (length > 3) {
-      finalText += ` + ${length - 3} more`;
+    // if number of votes more than 1 -> add  `+ "remaining users" more`
+    if (length > 1) {
+      finalText += ` + ${length - 1} more`;
     }
     return finalText;
   };
@@ -49,7 +58,10 @@ export function VoteSection({ question }: { question: Question }) {
         px: 0.5,
       }}
     >
-      <Tooltip title={`Upvoted by: ${getVoteTooltipText("upvotedBy")}`}>
+      <Tooltip
+        title={`Upvoted by: ${getVoteTooltipText("upvotedBy")}`}
+        placement="top"
+      >
         <IconButton
           aria-label="upvote"
           color={

--- a/src/pages/Explore.tsx
+++ b/src/pages/Explore.tsx
@@ -1,0 +1,49 @@
+import { Box } from "../utilities/material-ui/material-components";
+import {
+  QuestionCardsSection,
+  TrendingSection,
+  AddPostMobile,
+  Sidenav,
+} from "../components/index";
+import { Question } from "../types/Question";
+import React from "react";
+import { useAppDispatch, useAppSelector } from "../redux/customHook";
+import { RootState } from "../redux/store";
+import { IDLE } from "../utilities/constants/api-status";
+import { getQuestions } from "../redux/slices/feedSlice";
+
+export function Explore() {
+  const [open, setOpen] = React.useState(false);
+  const handleOpen = () => setOpen(true);
+  const dispatch = useAppDispatch();
+  const { questions, questionStatus } = useAppSelector(
+    (state: RootState) => state.feed
+  );
+  const [questionsToDisplay, setQuestionsToDisplay] = React.useState<
+    Question[]
+  >([]);
+
+  React.useEffect(() => {
+    if (questionStatus === IDLE) {
+      dispatch(getQuestions());
+    }
+    setQuestionsToDisplay(questions);
+  }, [questions]);
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        p: { md: "0 1rem 0 0", xs: "1rem" },
+        gap: 2,
+        flexDirection: { xs: "column-reverse", md: "row" },
+      }}
+      component="main"
+    >
+      <Sidenav handleOpen={handleOpen} open={open} setOpen={setOpen} />
+      <QuestionCardsSection title="Explore" questions={questionsToDisplay} />
+      <TrendingSection />
+      <AddPostMobile handleOpen={handleOpen} />
+    </Box>
+  );
+}

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -56,7 +56,7 @@ export function LandingPage() {
         </Box>
         {authToken ? (
           <Box component="div">
-            <Link to="/feed" style={{ textDecoration: "none" }}>
+            <Link to="/explore" style={{ textDecoration: "none" }}>
               <Button
                 variant="contained"
                 sx={{ width: "max-content", display: "flex", my: 1 }}

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -39,12 +39,7 @@ export function SignUp() {
     firstNameError: "",
     lastNameError: "",
   });
-  React.useEffect(() => {
-    // if user is already logged in and tries to access signup page, they will be redirected to previous page
-    if (authToken) {
-      navigate(-1);
-    }
-  }, []);
+
   React.useEffect(() => {
     if (authStatus === FULFILLED && authToken) {
       const lastState: any = location?.state;

--- a/src/pages/Signin.tsx
+++ b/src/pages/Signin.tsx
@@ -31,13 +31,6 @@ export function SignIn() {
   const dispatch = useAppDispatch();
 
   React.useEffect(() => {
-    // if user is already logged in and tries to access signin page, they will be redirected to previous page
-    if (authToken) {
-      navigate(-1);
-    }
-  }, []);
-
-  React.useEffect(() => {
     if (authStatus === FULFILLED && authToken) {
       const lastState: any = location?.state;
       const lastRoute: string = lastState?.from?.pathname || "/feed";

--- a/src/pages/feed.tsx
+++ b/src/pages/feed.tsx
@@ -10,39 +10,41 @@ import { useAppDispatch, useAppSelector } from "../redux/customHook";
 import { getQuestions } from "../redux/slices/feedSlice";
 import { RootState } from "../redux/store";
 import { Question } from "../types/Question";
+import { IDLE } from "../utilities/constants/api-status";
 
 export function Feed() {
   const [open, setOpen] = React.useState(false);
   const handleOpen = () => setOpen(true);
   const dispatch = useAppDispatch();
-  const { questions } =
-    useAppSelector((state: RootState) => state.feed);
+  const { questions, questionStatus } = useAppSelector(
+    (state: RootState) => state.feed
+  );
+  const { userDetails } = useAppSelector(
+    (state: RootState) => state.authentication
+  );
   const [questionsToDisplay, setQuestionsToDisplay] = React.useState<
     Question[]
   >([]);
 
   React.useEffect(() => {
-    if (questions.length === 0) {
+    //  fetch questions from db if not already fetched
+    if (questionStatus === IDLE) {
       dispatch(getQuestions());
     }
-  }, []);
-  React.useEffect(() => {
-    // questions posted by the accounts that the user follows and the ones that are not posted by the user
-    // setQuestionsToDisplay((value: Question[]) =>
-    //   questions?.filter((ques: Question) =>
-    //     userDetails.following.includes(ques.username)
-    //   )
-    // );
-    // temporarily displaying all questions
-    setQuestionsToDisplay([...questions]);
+    //  questions posted by the accounts that the user follows and the ones that are not posted by the user
+    setQuestionsToDisplay((value: Question[]) =>
+      questions?.filter((ques: Question) =>
+        userDetails.following.includes(ques.username)
+      )
+    );
   }, [questions]);
+
   return (
     <Box
       sx={{
         display: "flex",
-        p: { md: 0, xs: 2 },
+        p: { md: "0 1rem 0 0", xs: "1rem" },
         gap: 2,
-        pr: { md: 2 },
         flexDirection: { xs: "column-reverse", md: "row" },
       }}
       component="main"

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,3 +3,4 @@ export { Profile } from "./Profile";
 export { LandingPage } from "./LandingPage";
 export { SignIn } from "./Signin";
 export { SignUp } from "./SignUp";
+export { Explore } from "./Explore";

--- a/src/utilities/data/tags.ts
+++ b/src/utilities/data/tags.ts
@@ -1,0 +1,16 @@
+export const tags: string[] = [
+  "Cake",
+  "Baking",
+  "Baking Tools",
+  "Recipes",
+  "Cake Decoration",
+  "Pastry",
+  "Donuts",
+  "Breads",
+  "Wheat Bread",
+  "Cookies",
+  "Business",
+  "Icing",
+  "Experience",
+  "Bakers",
+];

--- a/src/utilities/material-ui/material-components.ts
+++ b/src/utilities/material-ui/material-components.ts
@@ -42,6 +42,7 @@ import Radio from "@mui/material/Radio";
 import RadioGroup from "@mui/material/RadioGroup";
 import Snackbar from "@mui/material/Snackbar";
 import TextField from "@mui/material/TextField";
+import ToggleButton from "@mui/material/ToggleButton";
 import Toolbar from "@mui/material/Toolbar";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
@@ -91,6 +92,7 @@ export {
   RadioGroup,
   Snackbar,
   TextField,
+  ToggleButton,
   Toolbar,
   Tooltip,
   Typography,

--- a/src/utilities/material-ui/material-icons.ts
+++ b/src/utilities/material-ui/material-icons.ts
@@ -5,9 +5,10 @@ import ChangeHistoryIcon from "@mui/icons-material/ChangeHistory";
 import FilterListIcon from "@mui/icons-material/FilterList";
 import LockOutlinedIcon from "@mui/icons-material/LockOutlined";
 import AddIcon from "@mui/icons-material/Add";
-import LogoutIcon from '@mui/icons-material/Logout';
-import CloseIcon from '@mui/icons-material/Close';
-import FeedOutlinedIcon from '@mui/icons-material/FeedOutlined';
+import LogoutIcon from "@mui/icons-material/Logout";
+import CloseIcon from "@mui/icons-material/Close";
+import FeedOutlinedIcon from "@mui/icons-material/FeedOutlined";
+import LoginIcon from "@mui/icons-material/Login";
 
 export {
   CommentOutlinedIcon,
@@ -19,5 +20,6 @@ export {
   AddIcon,
   LogoutIcon,
   CloseIcon,
-  FeedOutlinedIcon
+  FeedOutlinedIcon,
+  LoginIcon,
 };


### PR DESCRIPTION
This PR includes the following changes:
- explore page without filters
   - user cannot comment, upvote/downvote any post without logging in
   - user cannot follow/unfollow other accounts without logging in
- code refactoring
   - segregated comment section
   - minor bug fix in navigation on the sign in and sign up page
<img width="960" alt="image" src="https://user-images.githubusercontent.com/64582473/171258396-f446498a-0a82-4a25-b64d-0f093af2d831.png">
